### PR TITLE
Update Onepay SDK dependency version

### DIFF
--- a/OnepayMVCTest/Controllers/TransactionController.cs
+++ b/OnepayMVCTest/Controllers/TransactionController.cs
@@ -18,12 +18,7 @@ namespace OnepayMVCTest.Controllers
         {
             var jsonResponse = new Hashtable();
 
-            var channelType = ChannelType.Web;
-
-            if (channel.Equals("mobile", StringComparison.InvariantCultureIgnoreCase))
-                channelType = ChannelType.Mobile;
-            else if (channel.Equals("app", StringComparison.InvariantCultureIgnoreCase))
-                channelType = ChannelType.App;
+            var channelType = ChannelType.Parse(channel);
 
             var cart = GetCart();
             ShoppingCart shoppingCart = new ShoppingCart();

--- a/OnepayMVCTest/OnepayMVCTest.csproj
+++ b/OnepayMVCTest/OnepayMVCTest.csproj
@@ -118,8 +118,9 @@
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
     </Reference>
-    <Reference Include="Transbank, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\TransbankSDK.1.2.1\lib\netstandard1.3\Transbank.dll</HintPath>
+    <Reference Include="Transbank, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\TransbankSDK.1.3.0\lib\netstandard1.3\Transbank.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/OnepayMVCTest/packages.config
+++ b/OnepayMVCTest/packages.config
@@ -56,5 +56,5 @@
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
-  <package id="TransbankSDK" version="1.2.1" targetFramework="net46" />
+  <package id="TransbankSDK" version="1.3.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Change how we obtain a correct ChannelType by
using the new static method ChannelType.Parse